### PR TITLE
Bugfix/opp 161 C/O Folkeregistrert adresse

### DIFF
--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/constants.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/constants.js
@@ -3,3 +3,9 @@ export const API_BASE_URL = '/modiabrukerdialog/rest';
 export const UKEDAGER = ['MANDAG', 'TIRSDAG', 'ONSDAG', 'TORSDAG', 'FREDAG', 'LORDAG', 'SONDAG'];
 
 export const endash = '\u2013';
+
+export const ADRESSETYPER = {
+    GATEADRESSE: 'GATEADRESSE',
+    MATRIKKELADRESSE: 'MATRIKKELADRESSE',
+    INGEN_ADRESSE_REGISTRERT: 'INGEN_ADRESSE_REGISTRERT'
+};

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/reactkomponenter-module.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/reactkomponenter-module.js
@@ -12,6 +12,7 @@ import LeggTilbakeDelvisSvarPanel from './dialog-panel/leggtilbakedelvissvar/leg
 import TraadVisning from './dialog-panel/traadvisning/traadvisning-module';
 import RedirectModal from './redirectmodal/redirectmodal-module';
 import BrukersNavKontor from './visittkort/brukers-nav-kontor/nav-kontor-module';
+import FolkeregistrertAdresse from './visittkort/adresse/folkeregistrert-adresse-module';
 
 import React from './nav-react';
 import ReactDOM from 'react-dom';
@@ -30,7 +31,8 @@ window.ModiaJS = {
         LeggTilbakeDelvisSvarPanel,
         TraadVisning,
         RedirectModal,
-        BrukersNavKontor
+        BrukersNavKontor,
+        FolkeregistrertAdresse
     },
     InitializedComponents: {},
     React,

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/adresse.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/adresse.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PT from 'prop-types';
+
+import { ADRESSETYPER } from '../../../constants';
+import Gateadresse from './gateadresse';
+import Matrikkeladresse from './matrikkeladresse';
+
+function Adresse({ adresseType, adresse }) {
+    if (adresseType === ADRESSETYPER.INGEN_ADRESSE_REGISTRERT) {
+        return (<span>INGEN REGISTRERT ADRESSE</span>);
+    } else if (adresseType === ADRESSETYPER.GATEADRESSE) {
+        return (<Gateadresse adresse={adresse} />);
+    } else if (adresseType === ADRESSETYPER.MATRIKKELADRESSE) {
+        return (<Matrikkeladresse adresse={adresse} />);
+    }
+    return <span>Feil ved visning av adresse</span>;
+}
+
+Adresse.propTypes = {
+    adresseType: PT.string.isRequired,
+    adresse: PT.object
+};
+
+export default Adresse;

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/gateadresse.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/gateadresse.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PT from 'prop-types';
+
+function Gateadresse({ adresse }) {
+    const { gatenavn, husnummer, husbokstav, bolignummer, postnummer, poststed } = adresse;
+    const adresseLinje = `${gatenavn} ${husnummer}${husbokstav ? husbokstav : ''}${bolignummer ? ` ${bolignummer}` : ''}, ${postnummer} ${poststed}`;
+    return (<span>{adresseLinje}</span>);
+}
+
+Gateadresse.propTypes = {
+    adresse: PT.shape({
+        gatenavn: PT.string.isRequired,
+        husnumer: PT.string.isRequired,
+        husbokstav: PT.string,
+        bolignummer: PT.string,
+        postnummer: PT.string.isRequired,
+        poststed: PT.string.isRequired
+    }).isRequired
+};
+
+export default Gateadresse;

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/matrikkeladresse.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/matrikkeladresse.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PT from 'prop-types';
 
 function Matrikkeladresse({ adresse }) {
-    console.log(adresse);
     const { eiendomsnavn, postnummer, poststed } = adresse;
     const adresseLinje = `${eiendomsnavn ? `${eiendomsnavn}, ` : ''}${postnummer} ${poststed}`;
     return (<span>{adresseLinje}</span>);

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/matrikkeladresse.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/matrikkeladresse.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PT from 'prop-types';
+
+function Matrikkeladresse({ adresse }) {
+    console.log(adresse);
+    const { eiendomsnavn, postnummer, poststed } = adresse;
+    const adresseLinje = `${eiendomsnavn ? `${eiendomsnavn}, ` : ''}${postnummer} ${poststed}`;
+    return (<span>{adresseLinje}</span>);
+}
+
+Matrikkeladresse.propTypes = {
+    adresse: PT.shape({
+        eidendomsnavn: PT.string,
+        postnummer: PT.string.isRequired,
+        poststed: PT.string.isRequired
+    }).isRequired
+};
+
+export default Matrikkeladresse;

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/tilleggsadresse.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/components/tilleggsadresse.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import PT from 'prop-types';
+
+function Tilleggsadresse({ adresse }) {
+    if (!adresse) {
+        return null;
+    }
+    return (<span>{adresse}</span>);
+}
+
+Tilleggsadresse.propTypes = {
+    adresse: PT.string
+};
+
+export default Tilleggsadresse;

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/folkeregistrert-adresse-module-test.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/folkeregistrert-adresse-module-test.js
@@ -1,0 +1,14 @@
+import '../../test-config';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import FolkeregistrertAdresse from './folkeregistrert-adresse-module';
+
+describe('Folkeregistrert-adrese', () => {
+    it('skal rendre', () => {
+        const element = shallow(<FolkeregistrertAdresse />);
+
+        expect(element.find('.overskrift').length).to.equal(1);
+    });
+});

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/folkeregistrert-adresse-module.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/adresse/folkeregistrert-adresse-module.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PT from 'prop-types';
+
+import Adresse from './components/adresse';
+import Tilleggsadresse from './components/tilleggsadresse';
+
+class FolkeregistrertAdresse extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+    render() {
+        return (
+            <tr>
+                <th className="overskrift">Folkeregistrert adresse</th>
+                <td><Tilleggsadresse adresse={this.props.tilleggsadresse} /></td>
+                <td><Adresse {...this.props} /></td>
+            </tr>
+        );
+    }
+}
+
+FolkeregistrertAdresse.propTypes = {
+    adresseType: PT.string.isRequired,
+    adresse: PT.object,
+    tilleggsadresse: PT.string
+};
+
+export default FolkeregistrertAdresse;

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/visittkort.less
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/visittkort/visittkort.less
@@ -1,0 +1,24 @@
+.visittkort {
+
+  p {
+    text-transform: uppercase;
+    font-size: 1.3rem;
+    font-weight: bold;
+    font-family: Modus, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  }
+
+  span {
+    text-transform: uppercase;
+  }
+
+  .overskrift {
+    color: #b7b1a9;
+    text-transform: uppercase;
+    font-weight: normal;
+    font-family: Arial, Helvetica, sans-serif;
+    text-align: left;
+    margin-bottom: 0.2em;
+    font-size: 0.857rem;
+  }
+
+}


### PR DESCRIPTION
Lager en reactkomponent for visning av folkeregistrerte adresser. Kan forhåpentligvis gjenbrukes i visittkortet for visning av andre adresser.