### PR TITLE
OPP-260 Vis feilmelding fra serveren hvis den er satt i body

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <description>Fellesbibliotek for React-komponenter</description>
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>reactkomponenter</artifactId>
-    <version>2.10.15</version>
+    <version>2.10.15-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/journalforing-panel/journalfor-knapp.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/journalforing-panel/journalfor-knapp.js
@@ -3,6 +3,17 @@ import PT from 'prop-types';
 import Snurrepipp from '../utils/snurrepipp';
 import Ajax from './../utils/ajax';
 
+function getFeilmelding(err) {
+    if (!err) {
+        return null;
+    } else if (err.length <= 0) {
+        return null;
+    } else if (!err[0].response || !err[0].response.body) {
+        return null;
+    }
+    return err[0].response.body.message;
+}
+
 class JournalforKnapp extends React.Component {
     constructor(props) {
         super(props);
@@ -27,9 +38,13 @@ class JournalforKnapp extends React.Component {
         journalforPromise.done(() => {
             this.props.traadJournalfort();
         });
-        journalforPromise.fail(() => {
+        journalforPromise.fail((err) => {
             this.setState({ sender: false });
-            this.props.feiletCallback();
+            if (getFeilmelding(err)) {
+                this.props.feiletCallback(getFeilmelding(err));
+            } else {
+                this.props.feiletCallback();
+            }
         });
     }
 

--- a/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/journalforing-panel/journalfor-sak.js
+++ b/src/main/resources/no/nav/sbl/dialogarena/reactkomponenter/journalforing-panel/journalfor-sak.js
@@ -19,9 +19,11 @@ class JournalforSak extends React.Component {
         wicketSender(this.props.wicketurl, this.props.wicketcomponent, 'traadJournalfort');
     }
 
-    journalforingFeilet() {
+    journalforingFeilet(err) {
+        const defaultFeilmelding = 'Noe gikk galt. Det er dessverre ikke mulig å journalføre henvendelser, prøv igjen senere.';
+        const feilmelding = err || defaultFeilmelding;
         this.setState({
-            feilmeldinger: ['Noe gikk galt. Det er dessverre ikke mulig å journalføre henvendelser, prøv igjen senere.']
+            feilmeldinger: [feilmelding]
         });
     }
 


### PR DESCRIPTION
Spesifikt gjelder dette hvis enheten ikke er satt, da ønsker vi å vise
en custom feilmelding som anbefaler bruker å velge enhet på nytt